### PR TITLE
New features

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,90 @@
+from os.path import basename, normpath, join, abspath, exists
+from argparse import ArgumentParser
+from time import perf_counter
+from os import mkdir, getcwd
+from compileall import compile_dir
+import moduletools
+import bytecode
+from shutil import rmtree
+from sys import argv
+
+
+if __name__ == '__main__':
+    bytecode._is_main = True
+    runtime = perf_counter()
+
+    parser = ArgumentParser(prog='PyToPyc',
+                            description='Takes in a Python project directory and copies all the bytecodes and non-py files to an output directory.',
+                            epilog='Visit my GitHub: heatdeathnow')
+
+    parser.add_argument('input', help='The path to your Python code.')
+    parser.add_argument('-i', '--interpreter', action='store_true',
+                        help='Should the program pack a striped-down Python interpreter with the bytecode? Default is False.')
+    parser.add_argument('-n', '--name', required='--interpreter' in argv or '-i' in argv,
+                        help="The name of your program's `main.py` file (case sensitive).This argument is required if the --interpreter/-i option \
+                        is active.")
+    parser.add_argument('-o', '--output', type=str,
+                        help='Where a copy of the input directory will be created and the bytecode and other files dumped. Default is "bytecode\\"')
+    parser.add_argument('-s', '--suffix', type=str,
+                        help="The part of the bytecode files' name to be removed. The program already identifies the standard suffix names \
+                        automatically, but if the _suffixes do not follow the standard, they can be specified with this argument.")
+    parser.add_argument('-c', '--cache', type=str, default='__pycache__',
+                        help='The name of the folder where the Python interpreter has stored all the bytecode. The default is __pycache__')
+
+    args = parser.parse_args()
+
+    bytecode._user_suffix = args.suffix
+    bytecode._cache = args.cache
+    
+    args.input = bytecode._fix_slash(args.input)
+    if abspath(args.input) == getcwd():
+        raise PermissionError('Do not pass the working directory as an input. Either move this module outside your project or put your project \
+                              inside a subdirectory')
+
+    if args.name[-3:].lower() == '.py': 
+        args.name = args.name.replace('.py', '')
+    if not exists(join(args.input, f'{args.name}.py')):
+        raise ValueError(f'PyToPyc was unable to find {join(args.input, args.name)}\nKeep in mind the names are case sensitive.')
+
+    if args.output is None:
+        args.output = basename(normpath(args.input)) + ' - bytecode\\'
+    else:
+        args.output = bytecode._fix_slash(args.output)
+
+    # Start of the program
+    if args.interpreter:
+        moduletools.copy_python(join(args.output, 'pytopyc_tmp\\'))
+        bytecode._bytecide(join(args.output, 'pytopyc_tmp\\'), bytecode._cache)
+        compile_dir(join(args.output, 'pytopyc_tmp\\'), optimize=2)
+        bytecode._recurse_copy(join(args.output, 'pytopyc_tmp\\'), join(args.output, 'pytopyc_tmp\\'), join(args.output, 'Python\\'))
+        rmtree(join(args.output, 'pytopyc_tmp\\'))
+
+    bytecode._used_suffix = bytecode._user_suffix
+    try:
+        mkdir(args.output)  # Creates the output directory. If the interpreter option was not activated, it is necessary to create the output here.
+    except FileExistsError:
+        pass
+    
+    if args.interpreter:
+        start_script = f'@ECHO OFF\ncd bytecode\\\nstart pythonw -OO {args.name}.pyc %*\n'
+        debug_script = f'@ECHO ON\ncd bytecode\\\npython -OO {args.name}.pyc %*\npause\n'
+        bytecode._recurse_copy(args.input, args.input, join(args.output, 'bytecode'))
+
+        try:
+            with open(join(args.output, 'start.bat'), 'x') as file: file.write(start_script)
+        except FileExistsError:
+            with open(join(args.output, 'start.bat'), 'w') as file: file.write(start_script)
+
+        try:
+            with open(join(args.output, 'debug.bat'), 'x') as file: file.write(debug_script)
+        except FileExistsError:
+            with open(join(args.output, 'debug.bat'), 'w') as file: file.write(debug_script)    
+    else:
+        bytecode._recurse_copy(args.input, args.input, args.output)
+
+    try:
+        print(f'Total runtime: {perf_counter() - runtime:.2f} seconds.')
+        pass
+    except ZeroDivisionError:
+        print(f'Total runtime: 0 seconds.')
+        pass

--- a/moduletools.py
+++ b/moduletools.py
@@ -1,0 +1,114 @@
+from shutil import copy, copytree
+from os import listdir, makedirs
+from os.path import join, isdir
+import sys
+
+
+_runtime_imports = ['locale', ]
+
+def _get_modules() -> tuple:
+    """
+    This function gets a list of all modules imported when loading a program.
+    """
+
+    import __main__  # Imports the module which will import all modules used in the program.
+
+    indices = []
+    mods = [m for m in sys.modules.keys()]
+    for i, mod in enumerate(mods):
+        for mod_ in mods:
+            if mod_ + '.' in mod:
+                indices.append(i)
+                break
+    
+    for i in reversed(indices):
+        mods.pop(i)
+    mods.pop(mods.index('__main__'))
+    if __name__ != '__main__':
+        mods.pop(mods.index(__name__))
+    
+    mods.extend(_runtime_imports)
+    return mods
+
+
+def _get_python_path() -> str:
+    """
+    Returns the path to Python's installation directory.
+    """
+
+    version = ''.join(sys.version.split(' ')[0].split('.')[:-1])  # Gets a three number string according to the version. Python 3.11.4 would be 311.
+    for path in sys.path:
+        if f'Python{version}' in path[-len(f'Python{version}'):]:
+            return path
+            break
+    
+    raise FileNotFoundError("The program was unable to locate Python's installation directory.")
+
+
+def _from_python_dir(output: str, folder: str) -> None:
+    """
+    Goes into the specified folder in the PYTHONPATH and copies the modules inside that matches the ones specified in the module list.
+    """
+
+    python_path = _get_python_path()
+    modules = _get_modules()
+
+    for file in listdir(join(python_path, folder)):
+        if isdir(join(python_path, folder, file)) and file in modules:
+            try:
+                copytree(join(python_path, folder, file), join(join(output, folder, file)))
+            except FileNotFoundError:
+                makedirs(join(output, folder))
+                copytree(join(python_path, folder, file), join(join(output, folder, file)))
+            except FileExistsError:
+                print('Subdirectory has already been copied to the output directory. Ignoring it.')
+
+        if not isdir(join(python_path, folder, file)) and file.split('.')[0] in modules:  # Sometimes there are files and directories with the same name so `elif` can't be used.
+            try:
+                copy(join(python_path, folder, file), join(join(output, folder, file)))
+            except FileNotFoundError:
+                makedirs(join(output, folder))
+                copy(join(python_path, folder, file), join(join(output, folder, file)))
+            except FileExistsError:
+                print('File has already been copied to the output directory. Ignoring it.')
+
+def copy_python(output: str) -> None:
+    """
+    Copies a Python interpreter with the bare essentials to the output file. This function should be used inside a `setup.py` file which imports the
+    project's `main.py` file and `PyToPyc`. If the project uses modules that happen to be imported inside functions and not at the top of the file, then
+    there will be a need to update the _runtime_imports parameter located in this module's `__init__.py` file first. If that's not done, the program won't
+    be able to tell it's supposed to import those modules as well.
+    """
+
+    python_path = _get_python_path()
+    files = [file for file in listdir(python_path) if not isdir(join(python_path, file))]
+    for file in files:
+        try:
+            copy(join(python_path, file), join(output, file))
+        except FileNotFoundError:
+            makedirs(output)
+            copy(join(python_path, file), join(output, file))
+        except FileExistsError:
+            print('File has already been copied to the output directory. Ignoring it.')
+
+    _from_python_dir(output, 'DLLs')
+    _from_python_dir(output, 'Lib')
+    _from_python_dir(output, 'Tools\\demo')
+    _from_python_dir(output, 'Tools\\i18n')
+    _from_python_dir(output, 'Tools\\scripts')
+
+    try:
+        copytree(join(python_path, 'libs'), join(output, 'libs'))
+    except FileNotFoundError:
+        makedirs(join(output, 'libs'))
+        copytree(join(python_path, 'libs'), join(output, 'libs'))
+    except FileExistsError:
+        print('Subdirectory has already been copied to the output directory. Ignoring it.')
+    
+    try:
+        copytree(join(python_path, 'Scripts'), join(output, 'Scripts'))
+    except FileNotFoundError:
+        makedirs(join(output, 'Scripts'))
+        copytree(join(python_path, 'Scripts'), join(output, 'Scripts'))
+    except FileExistsError:
+        print('Subdirectory has already been copied to the output directory. Ignoring it.')

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,34 @@
+# PyToPyc
+Can recreate a new directory from an input directory exactly like the first one, but with the `.py` files replaced by `.pyc` files.
+Can get the modules that are used in your project and copy your Python's installation with the bare-minimum essentials to run your project. It then can create two batch scripts (two `.bat` files) to start your program from the bare-minimum Python interpreter packed inside your distribution file.
+
+## To be done
+- Have the packing of the Python interpreter be doable from the command prompt rather than having to create a `setup.py` file. 
+- Get a way to figure out all the modules that are imported and those that _could come to be imported_ in the project.
+- Organize the package as so to not clutter the IDE with random junk like variables and function that shouldn't show up.
+
+### Python Packing
+This can pack a Python distribution inside your program's distribution output folder so that users that do not have Python installed in their computers can run this project.
+
+### Batch scripts
+This can create two batch scripts to activate the program in a cleaner way for the end-user.
+Ultimately, the distribution folder will have the following subdirectories: Python\ (the packed-in interpreter), bytecode\ (your program's bytecode), start.bat (for starting the program without a prompt), and debug.bat (for starting the program with a prompt).
+
+### Automatic suffix detection
+The program automatically detects common suffixes added to the bytecode file names by the Python interpreter. These are:
+- .cpython-311
+- .cpython-311.opt-1
+- .cpython-311.opt-2
+
+If the interpreter used a different suffix for the bytecode file name, then the user can specify it by calling the `--suffix` or `-s` argument.
+
+### Bytecode folder detection
+The program is made as to expect the bytecode to always be inside a folder, as is costumary for Python for quite some time now. The default value for this folder is `__pycache__` but it can be specified by calling the `--cache` or the `-c` argument.
+
+### Best way to use PyToPyc
+1. Delete all the bytecode from your program.
+2. Run your program with the command: `python -OO your_programs_main_file.py`.
+
+This is essential because the interpreter will then create just the necessary bytecode for running the program. There can be situations in which there is more bytecode than necessary (from unused modules and such). Furthermore, by passing the `-OO` argument, docstrings and `assert` statements will not be put in the bytecode, saving space.
+
+3. Run PyToPyc with the following command: `PyToPyc.py your_programs_directory new_directory`.


### PR DESCRIPTION
Packing your Python interpreter with the bare-minimum of the modules that are used by a project. Creating two batch files for the end user to start or debug your project.

`bytecode._bytecide` will go into a directory and remove all the bytecode cache files. The `moduletools` module is for getting used modules and packing the user's Python interpreter inside the project with the used builtin modules.